### PR TITLE
feat!: Fixing how better_deferred decorates the script elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ For example, if an element to declare Calendly isn't visible yet, then I'd like 
 
 This library support addition of custom MIME types when the script is loaded. This defaults to `type="application/javascript"` this can be overridden by setting `data-mime-type` value. For example for ESM, the `type="module"` needs to be set, since this is deferred, this can be set as `data-mime-type="module` or any of the [JS IANA types](http://www.iana.org/assignments/media-types/media-types.xhtml).
 
+```
+<script type="better_deferred" data-mime-type="module">
+   import * as d3 from 'https://esm.run/d3';
+   console.log('esm module', d3);
+</script>
+```
+
 ## Customization
 By default inline scripts and external scripts will be
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please note that not all scripts are a good candidate to defer. For example, jQu
 
 The following scripts is executed after (document.ready + 5 seconds):
 ```
-<script type="better_deferred_inline" onload="console.log('loaded inline script');">
+<script type="better_deferred" onload="console.log('loaded script');">
    alert('loaded');
 </script>
 ```
@@ -31,15 +31,19 @@ When scripts are loaded, they are given the type `better_deferred_*_loaded` and 
 # Support for lozad
 A case I wanted to support is to load external scripts earlier if they become relevant to the user by detecting whether lozad has loaded related elements in the page.
 
-For example, if an element to declare Calendly isn't visible yet, then I'd like to lazy load the Calendly script except if the element becomes visible and the user is likely to interact with it. So this library sets Mutation observers for `better_deferred` and `better_deferred_inline` scripts when the parent has the `lozad` class. Upon lozad making the element visible, this library detects changes to `data-loaded` and will immediate start loading all deferred scripts.
+For example, if an element to declare Calendly isn't visible yet, then I'd like to lazy load the Calendly script except if the element becomes visible and the user is likely to interact with it. So this library sets Mutation observers for `better_deferred` scripts when the parent has the `lozad` class. Upon lozad making the element visible, this library detects changes to `data-loaded` and will immediate start loading all deferred scripts.
+
+## Mime Types
+
+This library support addition of custom MIME types when the script is loaded. This defaults to `type="application/javascript"` this can be overridden by setting `data-mime-type` value. For example for ESM, the `type="module"` needs to be set, since this is deferred, this can be set as `data-mime-type="module` or any of the [JS IANA types](http://www.iana.org/assignments/media-types/media-types.xhtml).
 
 ## Customization
-By default inline scripts and external scripts will be 
+By default inline scripts and external scripts will be
 ```
 window['_bd_timeout'] = 5000;
 ```
 
-To prevent name collision, this library is instantiated in 
+To prevent name collision, this library is instantiated in
 `window[window['_bd_name']]`. This means that you can use the following pattern to set where this object is stored.
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please note that not all scripts are a good candidate to defer. For example, jQu
 
 The following scripts is executed after (document.ready + 5 seconds):
 ```
-<script type="better_deferred" onload="console.log('loaded script');">
+<script type="better_deferred" onload="console.log('loaded inline script');">
    alert('loaded');
 </script>
 ```

--- a/index.html
+++ b/index.html
@@ -6,8 +6,10 @@
         <script type="better_deferred" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.min.js"></script>
 
         <script type="better_deferred">
+            console.log('better_deferred inline has been loaded');
+
             $(document).ready(function() {
-                console.log('done');
+                console.log('document.ready is done');
                 $('#loaded-status').text('done');
                 updateBackgroundForLozad();
             })
@@ -23,9 +25,19 @@
                 $('#loaded-lozad-status').text('done');
             }
         </script>
+
+        <script type="better_deferred" data-mime-type="module">
+            import * as d3 from 'https://esm.run/d3';
+            console.log('esm module', d3);
+            $('#loaded-status-esm').text('done [module=' + typeof(d3) + ']');
+        </script>
     </head>
 
     <body>
+        <div>
+            ESM module. Status: <span id='loaded-status-esm'>Loading...</span>
+        </div>
+
         <div>
             JS scripts. Status: <span id='loaded-status'>Loading...</span>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
         <script src="dist/bundle.js"></script>
 
         <script type="better_deferred" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script type="better_deferred" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.min.js"></script>
+        <script type="better_deferred" data-test-tag='test-test' src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.min.js"></script>
 
         <script type="better_deferred">
             console.log('better_deferred inline has been loaded');

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <html>
-    <head>    
+    <head>
         <script src="dist/bundle.js"></script>
-        
+
         <script type="better_deferred" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
         <script type="better_deferred" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.min.js"></script>
 
-        <script type="better_deferred_inline">
+        <script type="better_deferred">
             $(document).ready(function() {
                 console.log('done');
                 $('#loaded-status').text('done');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_deferred",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Javascript library that truly defers the insertion of other Javascript libraries resulting in improved performance compared to using native defer or async.",
   "main": "src/index.js",
   "files": [

--- a/src/better_deferred.js
+++ b/src/better_deferred.js
@@ -18,7 +18,7 @@ const decorate = (element, callback = null) => {
 
 const addScriptObjects = (element, callback = null) => {
     log('Added script ' + element.src);
-    decorate(element, false, callback);
+    decorate(element, callback);
 }
 
 const fastLoadObserver = (betterDeferredObj) => {

--- a/src/better_deferred.js
+++ b/src/better_deferred.js
@@ -1,4 +1,3 @@
-const INLINE = 'better_deferred_inline';
 const DEFERRED = 'better_deferred';
 const TIMEOUT = 200;
 
@@ -11,17 +10,9 @@ const log = (s, level = 0) => {
     }
 }
 
-const decorate = (element, inline, callback = null) => {
-    var s = document.createElement("script");    
-    if (inline) {
-        s.innerHTML = element.innerHTML;
-    } else {
-        s.src = element.src;
-    }
-    s.type = "text/javascript";
-    s.addEventListener("load", element.onload);
-    element.type = `${element.type}_loaded`
-    document.body.appendChild(s);
+const decorate = (element, callback = null) => {
+    element.type = element.dataset.mimeType ?? "text/javascript";
+    document.body.appendChild(element);
     callback?.call();
 }
 
@@ -30,18 +21,13 @@ const addScriptObjects = (element, callback = null) => {
     decorate(element, false, callback);
 }
 
-const addInlineScriptObjects = (element, callback = null) => {
-    log('Added inline script');
-    decorate(element, true, callback);
-}
-
 const fastLoadObserver = (betterDeferredObj) => {
     let elems = document.querySelectorAll(".better_deferred_trigger");
     if (elems.length == 0) {
         return ;
     }
 
-    const trigger = () => { 
+    const trigger = () => {
         betterDeferredObj.start();
     }
 
@@ -53,7 +39,7 @@ const fastLoadObserver = (betterDeferredObj) => {
 
 }
 
-const lozadObserver = () => {  
+const lozadObserver = () => {
     let lozads = document.querySelectorAll(".lozad");
     if (lozads.length == 0) {
         return ;
@@ -73,48 +59,32 @@ const lozadObserver = () => {
             log(`Script in lozad will be loading now`, 1);
             let queue = fetchBetterDeferred(mutation.target);
             loadScriptsFromQueue(queue);
-            
+
             // Stop observing
-            observer.disconnect();  
+            observer.disconnect();
         }
     };
 
     // Create an observer instance linked to the callback function
     const observer = new MutationObserver(callback);
-    
+
     lozads.forEach((element) => {
         // Start observing the target node for configured mutations
         observer.observe(element, config);
     });
 }
 
-const loadScriptsFromQueue = (queue) => {
-    for(const elem of queue) {
-        let inline = elem.type == INLINE;
-        log(`Processing lozad script - inline? ${inline}`);
-        if (!inline) {
-            addScriptObjects(elem);
-        } else {
-            addInlineScriptObjects(elem);
-        }
-    }
-}
+const loadScriptsFromQueue = (queue) => queue.forEach((elem) => addScriptObjects(elem));
 
 const fetchBetterDeferred = (parent = document) => {
-    let queue = [];
-    let externalScripts = parent.querySelectorAll("script[type=" + DEFERRED + "]");
-    externalScripts.forEach((element) => {
-        queue.push(element);
-    });
+    const queue = Array.from(parent.querySelectorAll(`script[type^="${DEFERRED}"]`));
 
-    let inlineScripts = parent.querySelectorAll("script[type=" + INLINE + "]");
-    inlineScripts.forEach((element) => {
-        queue.push(element);
-    });
-
-    log(`Found ${externalScripts.length} ext scripts, ${inlineScripts.length} inline scripts. Queue ${queue.length}`, 1);
-    return queue;
-};
+    // Since we want to preserve the load order and load external scripts first and then inline scripts.
+    return [
+        ...queue.filter((elem) => elem.innerHTML === ''),
+        ...queue.filter((elem) => elem.innerHTML !== ''),
+    ];
+}
 
 let self = null;
 export class BetterDeferred {
@@ -134,11 +104,11 @@ export class BetterDeferred {
             self.queue = fetchBetterDeferred();
             self.next();
         };
-        
+
         log("Loading deferred scripts", 1);
         callback.apply(self);
     }
-    
+
     getQueue() {
         return this.queue;
     }
@@ -149,8 +119,7 @@ export class BetterDeferred {
             log('Complete', 1);
             return ;
         }
-        let inline = elem.type == INLINE;
-        log(`Another script processed. Remaining. ${this.getQueue().length} - inline? ${inline}`);
+        log(`Another script processed. Remaining. ${this.getQueue().length}`);
 
         let callback = () => {
             setTimeout(() => {
@@ -159,10 +128,6 @@ export class BetterDeferred {
             }, TIMEOUT);
         }
 
-        if (!inline) {
-            addScriptObjects(elem, callback);
-        } else {
-            addInlineScriptObjects(elem, callback);
-        }
+        addScriptObjects(elem, callback);
     }
 }


### PR DESCRIPTION
In this PR:

- Breaking Change: `better_deferred_inline` is no longer necessary.
- Instead of creating a new element, we can now update the existing element and add it back to DOM.
- Instead of looking for different types of `better_deferred` we now look for `innerHTML`, if the script exists as inline, it gets loaded after external scripts.
- Maintains backward-compatibility with existing `better_deferred_inline` because now we search for `script[type^="${DEFERRED}"]` which accounts for that.
- Added support for additional MIME types using `data-mime-type`